### PR TITLE
Swift filter() method syntax updated

### DIFF
--- a/IsoCountryCodes.swift
+++ b/IsoCountryCodes.swift
@@ -9,23 +9,23 @@
 class IsoCountryCodes {
     
     class func find( key:String ) -> IsoCountryInfo {
-        var country = filter( IsoCountries.allCountries, { $0.alpha2 == key.uppercaseString || $0.alpha3 == key.uppercaseString || $0.numeric == key } )
+        var country = IsoCountries.allCountries.filter(  { $0.alpha2 == key.uppercaseString || $0.alpha3 == key.uppercaseString || $0.numeric == key } )
         return country[0]
     }
     
     class func searchByName( name:String ) -> IsoCountryInfo {
-        var country = filter( IsoCountries.allCountries, { $0.name == name } )
+        var country = IsoCountries.allCountries.filter( { $0.name == name } )
         
         return (!country.isEmpty) ? country[0] : IsoCountryInfo(name: "", numeric: "", alpha2: "", alpha3: "", calling: "", currency: "", continent: "")
     }
     
    class func searchByCurrency( currency:String ) -> [IsoCountryInfo] {
-        var country = filter( IsoCountries.allCountries, { $0.currency == currency } )
+        let country = IsoCountries.allCountries.filter(  { $0.currency == currency } )
         return country
     }
     
    class func searchByCallingCode( calllingCode:String ) -> IsoCountryInfo {
-       var country = filter( IsoCountries.allCountries, { $0.calling == calllingCode } )
+       var country = IsoCountries.allCountries.filter( { $0.calling == calllingCode } )
        return country[0]
    }
 }


### PR DESCRIPTION
After error reported by Xcode: filter is unavailable call the filter()
method on the sequence
