### PR TITLE
Made matching by name case- and diacritic-insensitive, and trying par…

### DIFF
--- a/IsoCountryCodes.swift
+++ b/IsoCountryCodes.swift
@@ -15,7 +15,25 @@ class IsoCountryCodes {
     }
 
     class func searchByName(_ name: String) -> IsoCountryInfo? {
-        let countries = IsoCountries.allCountries.filter({ $0.name == name })
+        let options: String.CompareOptions = [.diacriticInsensitive, .caseInsensitive]
+        let name = name.folding(options: options, locale: .current)
+        let countries = IsoCountries.allCountries.filter({ $0.name.folding(options: options, locale: .current) == name })
+        // If we cannot find a full name match, try a partial match
+        return countries.count == 1 ? countries.first : searchByPartialName(name)
+    }
+
+    private class func searchByPartialName(_ name: String) -> IsoCountryInfo? {
+        guard name.count > 3 else {
+            return nil
+        }
+        let options: String.CompareOptions = [.diacriticInsensitive, .caseInsensitive]
+        let name = name.folding(options: options, locale: .current)
+        let countries = IsoCountries.allCountries.filter({ $0.name.folding(options: options, locale: .current).contains(name) })
+        // It is possible that the results are ambiguous, in that case return nothing
+        // (e.g., there are two Koreas and two Congos)
+        guard countries.count == 1 else {
+            return nil
+        }
         return countries.first
     }
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a **iOS Swift** library/class  files that does a simple lookup depending
 This library returns ISO codes, names and currencies for countries.
 
 - [x] Find by alpha-2, alpha-3 or numeric (String - yes I know...)
-- [x] Search by name
+- [x] Search by (partial) name, case- and diacritic insensitive
 - [x] Search by currency code
 - [x] Search by phone dialing code (+31 for Netherlands, +1 for USA, etc...)
 - [x] Retrieve a corresponding emoji flag for a country code.
@@ -49,6 +49,29 @@ This returns a `IsoCountryInfo` struct:
     - calling: +31
     - currency: EUR
     - continent: EU
+```
+Searching by name is case- and diacritic insensitive:
+
+```swift
+dump(IsoCountryCodes.searchByName("netherlands"))
+dump(IsoCountryCodes.searchByName("NETHERLANDS"))
+
+dump(IsoCountryCodes.searchByName("Réunion"))
+dump(IsoCountryCodes.searchByName("Reunion"))
+```
+If no full match is found, a partial match is tried:
+
+```swift
+// Full name is "Venezuela, Bolivarian Republic of"
+dump(IsoCountryCodes.searchByName("Venezuela"))
+```
+but nothing is returned if the search results would be ambiguous:
+
+```swift
+// There are two Virgin Islands country codes:
+// "Virgin Islands, British" and "Virgin Islands, U.S."
+dump(IsoCountryCodes.searchByName("Virgin Islands"))
+
 ```
 
 ### Fun with flags


### PR DESCRIPTION
…tial matching if full match fails

- Matching by name now ignores case and diacritics, by use of string folding
- A full match is preferred but if none was found, a partial match is attempted
- If there are ambiguous results for partial matching, return nil
- Added examples in Readme.md
