### PR TITLE
Search by calling code returns all matching countries

### DIFF
--- a/IsoCountryCodes.swift
+++ b/IsoCountryCodes.swift
@@ -17,7 +17,9 @@ class IsoCountryCodes {
     class func searchByName(_ name: String) -> IsoCountryInfo? {
         let options: String.CompareOptions = [.diacriticInsensitive, .caseInsensitive]
         let name = name.folding(options: options, locale: .current)
-        let countries = IsoCountries.allCountries.filter({ $0.name.folding(options: options, locale: .current) == name })
+        let countries = IsoCountries.allCountries.filter({
+            $0.name.folding(options: options, locale: .current) == name
+        })
         // If we cannot find a full name match, try a partial match
         return countries.count == 1 ? countries.first : searchByPartialName(name)
     }
@@ -28,7 +30,9 @@ class IsoCountryCodes {
         }
         let options: String.CompareOptions = [.diacriticInsensitive, .caseInsensitive]
         let name = name.folding(options: options, locale: .current)
-        let countries = IsoCountries.allCountries.filter({ $0.name.folding(options: options, locale: .current).contains(name) })
+        let countries = IsoCountries.allCountries.filter({
+            $0.name.folding(options: options, locale: .current).contains(name)
+        })
         // It is possible that the results are ambiguous, in that case return nothing
         // (e.g., there are two Koreas and two Congos)
         guard countries.count == 1 else {
@@ -47,8 +51,8 @@ class IsoCountryCodes {
         return countries
     }
 
-    class func searchByCallingCode(_ calllingCode: String) -> IsoCountryInfo? {
+    class func searchByCallingCode(_ calllingCode: String) -> [IsoCountryInfo] {
         let countries = IsoCountries.allCountries.filter({ $0.calling == calllingCode })
-        return countries.first
+        return countries
     }
 }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can also search by country name, currency or calling/dialing code:
 ```swift
 dump(IsoCountryCodes.searchByName("Netherlands")
 print(IsoCountryCodes.searchByCurrency("EUR").count ) // 31
-print(IsoCountryCodes.searchByCallingCode("+31").name ) // Netherlands
+print(IsoCountryCodes.searchByCallingCode("+31").first ) // Netherlands
 
 let country = IsoCountryCodes.searchByName("Netherlands")
 dump(country) // This dumps the full struct in console


### PR DESCRIPTION
Some calling codes match more than one country (e.g., +1 matches CAN, USA and UMI), so return all matching countries instead of only the first. Similar to searching by currency.

Also broke up some lines that were too long for Swiftlint.

